### PR TITLE
use int type for indexes

### DIFF
--- a/95/script.go
+++ b/95/script.go
@@ -435,7 +435,7 @@ func newTrack(path string) *Track {
 		colorData := make([]uint8, 3*2*rowLength*rowCount)
 		textureCoordData := make([][2]float32, 2*rowLength*rowCount)
 
-		var index uint64
+		var index int
 		for y := uint16(1); y < track.Depth; y++ {
 			for x := uint16(0); x < track.Width; x++ {
 				for i := uint16(0); i < 2; i++ {


### PR DESCRIPTION
GopherJS emulates a 32-bit architecture, since numbers in JS have a maximum integer precision of 53 bit. So `int` has 32 bits. According to the Go spec: `The length is part of the array's type; it must evaluate to a non-negative constant representable by a value of type int.` This means that it is valid to only support arrays/slices up to a length of 32 bits. Currently GopherJS does not enforce this, maybe it should. Nevertheless, an `uint64` as an index can still only address elements up to the maximum `int` and using `int` instead yields a better performance.
